### PR TITLE
Claude/r package improvements rishtq

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -128,7 +128,11 @@ jobs:
         run: |
           ## Enable installing XML from source if needed
           brew install libxml2
-          echo "XML_CONFIG=/usr/local/opt/libxml2/bin/xml2-config" >> $GITHUB_ENV
+          ## Resolve the Homebrew prefix dynamically: it's /usr/local on
+          ## Intel runners but /opt/homebrew on Apple Silicon (macOS-latest
+          ## runners moved to arm64), and a hardcoded /usr/local path leaves
+          ## XML_CONFIG pointing at a nonexistent file there.
+          echo "XML_CONFIG=$(brew --prefix libxml2)/bin/xml2-config" >> $GITHUB_ENV
 
           ## Required to install magick as noted at
           ## https://github.com/r-lib/usethis/commit/f1f1e0d10c1ebc75fd4c18fa7e2de4551fd9978f#diff-9bfee71065492f63457918efcd912cf2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,8 +21,10 @@ Imports: dplyr,
 Suggests: knitr,
     rmarkdown,
     devtools,
-    BiocStyle
+    BiocStyle,
+    testthat (>= 3.0.0)
 VignetteBuilder: knitr
+Config/testthat/edition: 3
 biocViews:
     Proteomics,
     CellBiology,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Imports: dplyr,
 Suggests: knitr,
     rmarkdown,
     devtools,
-    BiocStyle,
     testthat (>= 3.0.0)
 VignetteBuilder: knitr
 Config/testthat/edition: 3

--- a/R/download.R
+++ b/R/download.R
@@ -416,7 +416,7 @@ hpaExport <- function(data, fileName, fileType = 'xlsx') {
     # If the user specifies CSV format
     if (fileType == 'csv') {
         # Loop through each dataset in the list
-        for (i in 1:length(data)) {
+        for (i in seq_along(data)) {
             # Save each dataset as a separate .csv file
             write.csv(data[[i]],
                       file = paste0(fileName, "_", names(data[i]), ".csv"))
@@ -426,7 +426,7 @@ hpaExport <- function(data, fileName, fileType = 'xlsx') {
     # If the user specifies TSV format
     if (fileType == 'tsv') {
         # Loop through each dataset in the list
-        for (i in 1:length(data)) {
+        for (i in seq_along(data)) {
             # Save each dataset as a separate .tsv file
             write.table(data[[i]],
                         file = paste0(fileName, "_", names(data[i]), ".tsv"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,16 +15,6 @@ named_vector_list_to_tibble <- function(x) {
     }
     
     # process tibble_x into final product
-    ## the old way used tidyr::spread
-    # tibble_x <- tibble_x %>%
-    #     # remove the NA row resulted from defining tibble_x
-    #     filter(!is.na(index)) %>%
-    #     # spead tibble_x into tidy format
-    #     spread(attr, value) %>%
-    #     # remove the index column
-    #     select(-index)
-    
-    ## the new way used stats::reshape
     tibble_x <- tibble_x %>%
         # remove the NA row resulted from defining tibble_x
         filter(!is.na(index)) %>%

--- a/R/vis.R
+++ b/R/vis.R
@@ -88,7 +88,8 @@ hpaVisTissue <- function(data = NULL,
             xlab('Genes') +
             theme_minimal() +
             theme(panel.grid = element_blank()) +
-            theme(axis.text.x = element_text(angle = 90, hjust = 1))
+            theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
+            coord_equal()
     }
 
     return(plot)
@@ -305,7 +306,8 @@ hpaVisSubcell <- function(data = NULL,
             xlab('Genes') +
             theme_minimal() +
             theme(panel.grid = element_blank()) +
-            theme(axis.text.x = element_text(angle = 45, hjust = 1))
+            theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
+            coord_equal()
     }
     
     return(plot)

--- a/R/vis.R
+++ b/R/vis.R
@@ -88,8 +88,7 @@ hpaVisTissue <- function(data = NULL,
             xlab('Genes') +
             theme_minimal() +
             theme(panel.grid = element_blank()) +
-            theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
-            coord_equal()
+            theme(axis.text.x = element_text(angle = 90, hjust = 1))
     }
 
     return(plot)
@@ -306,8 +305,7 @@ hpaVisSubcell <- function(data = NULL,
             xlab('Genes') +
             theme_minimal() +
             theme(panel.grid = element_blank()) +
-            theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
-            coord_equal()
+            theme(axis.text.x = element_text(angle = 45, hjust = 1))
     }
     
     return(plot)

--- a/R/vis.R
+++ b/R/vis.R
@@ -272,35 +272,12 @@ hpaVisSubcell <- function(data = NULL,
     plotData <- data$subcellular_location %>%
         filter(gene %in% targetGene) %>%
         mutate(sub_location = NA)
-    
-    # if ("enhanced" %in% reliability)
-    #     plotData <- mutate(plotData,
-    #                        sub_location =  paste(sub_location, enhanced, sep = ";"))
-    # if ("supported" %in% reliability)
-    #     plotData <- mutate(plotData,
-    #                        sub_location =  paste(sub_location, supported, sep = ";"))
-    # if ("approved" %in% reliability)
-    #     plotData <- mutate(plotData,
-    #                        sub_location =  paste(sub_location, approved, sep = ";"))
-    # if ("uncertain" %in% reliability)
-    #     plotData <- mutate(plotData,
-    #                        sub_location =  paste(sub_location, uncertain, sep = ";"))
-    
+
     for (i in reliability) {
-        plotData <- mutate(plotData, 
+        plotData <- mutate(plotData,
                            sub_location = paste(sub_location, .data[[i]], sep = ";"))
     }
-    
-    # plotData <-  plotData %>%
-    #     mutate(sub_location=strsplit(sub_location, ';')) %>%
-    #     tidyr::unnest(sub_location) %>%
-    #     select(sub_location, gene) %>%
-    #     filter(sub_location != "NA") %>%
-    #     table() %>%
-    #     as_tibble() %>%
-    #     mutate(n=factor(n, levels=c('0', '1')))
-    
-    ## Use apply(as_tibble) %>% bind_rows instead of unnest
+
     plotData <-  plotData %>%
         mutate(sub_location = strsplit(sub_location, ';')) %>%
         apply(MARGIN = 1, FUN = as_tibble) %>% bind_rows() %>%

--- a/R/xml.R
+++ b/R/xml.R
@@ -286,24 +286,3 @@ patient_nodes_to_tibble <- function(patientNodes) {
     
     return(result)
 }
-
-## Melt a list into a data frame =============================================
-# @importFrom tidyr spread unnest
-
-# list_to_df <- function(listfordf){
-#     
-#     df <- list(list.element = listfordf)
-#     class(df) <- c("tbl_df", "data.frame")
-#     attr(df, "row.names") <- .set_row_names(length(listfordf))
-#     
-#     if (!is.null(names(listfordf))) {
-#         df$name <- names(listfordf)
-#     }
-#     
-#     df <- df %>% 
-#         spread(key = 'name', value = 'list.element') %>% 
-#         unnest() %>% 
-#         unnest()
-#     
-#     return(df)
-# }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,4 +9,15 @@
 library(testthat)
 library(HPAanalyze)
 
-test_check("HPAanalyze")
+# Bioconductor's build system sets IS_BIOC_BUILD_MACHINE (the same env var
+# testthat::skip_on_bioc() checks). The suite still runs in full under
+# GitHub Actions and locally, where this variable is never set.
+if (isTRUE(as.logical(Sys.getenv("IS_BIOC_BUILD_MACHINE", "false")))) {
+  message(
+    "Skipping the testthat suite: running on Bioconductor's build system ",
+    "(IS_BIOC_BUILD_MACHINE is set). The suite still runs in GitHub Actions ",
+    "and locally."
+  )
+} else {
+  test_check("HPAanalyze")
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(HPAanalyze)
+
+test_check("HPAanalyze")

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -1,0 +1,33 @@
+test_that("hpaDownload with downloadList=NULL lists available table names", {
+    tableNames <- hpaDownload(downloadList = NULL, version = "v25")
+    expect_type(tableNames, "character")
+    expect_true(all(c("normal_tissue", "pathology", "subcellular_location") %in% tableNames))
+})
+
+test_that("hpaDownload returns the built-in dataset for the example/built-in version", {
+    expect_message(
+        out <- hpaDownload(downloadList = "histology", version = "example"),
+        "example/built-in datasets"
+    )
+    expect_identical(out, HPAanalyze::hpa_histology_data)
+
+    expect_message(
+        out2 <- hpaDownload(downloadList = "all", version = "built-in")
+    )
+    expect_identical(out2, HPAanalyze::hpa_histology_data)
+})
+
+test_that(".replace_shortcut expands a shortcut in place", {
+    out <- .replace_shortcut(c("a", "all", "b"), "all", c("x", "y"))
+    expect_equal(out, c("a", "x", "y", "b"))
+})
+
+test_that(".replace_shortcut leaves input untouched when shortcut is absent", {
+    out <- .replace_shortcut(c("a", "b"), "all", c("x", "y"))
+    expect_equal(out, c("a", "b"))
+})
+
+test_that(".expand_download_list expands the 'histology' shortcut", {
+    out <- .expand_download_list("histology", hpa_download_list)
+    expect_equal(out, c("normal_tissue", "pathology", "subcellular_location"))
+})

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -1,5 +1,6 @@
 test_that("hpaDownload with downloadList=NULL lists available table names", {
-    tableNames <- hpaDownload(downloadList = NULL, version = "v25")
+    latestVersion <- paste0("v", max(hpa_download_list$version_number))
+    tableNames <- hpaDownload(downloadList = NULL, version = latestVersion)
     expect_type(tableNames, "character")
     expect_true(all(c("normal_tissue", "pathology", "subcellular_location") %in% tableNames))
 })

--- a/tests/testthat/test-subset-export.R
+++ b/tests/testthat/test-subset-export.R
@@ -1,0 +1,66 @@
+data("hpa_histology_data")
+
+test_that("hpaSubset filters by gene, mixing HGNC symbols and ensembl ids", {
+    sub <- hpaSubset(
+        data = hpa_histology_data,
+        targetGene = c("TP53", "ENSG00000146648"), # ENSG00000146648 == EGFR
+        targetTissue = "Breast"
+    )
+    expect_setequal(unique(sub$normal_tissue$gene), c("TP53", "EGFR"))
+    expect_setequal(unique(sub$normal_tissue$tissue), "Breast")
+    expect_setequal(unique(sub$pathology$gene), c("TP53", "EGFR"))
+})
+
+test_that("hpaSubset falls back to the built-in dataset when data is NULL", {
+    expect_message(
+        sub <- hpaSubset(data = NULL, targetGene = "TP53"),
+        "No data provided"
+    )
+    expect_setequal(unique(sub$normal_tissue$gene), "TP53")
+})
+
+test_that("hpaSubset returns unfiltered data when no target is specified", {
+    sub <- hpaSubset(data = hpa_histology_data)
+    expect_identical(sub, hpa_histology_data)
+})
+
+test_that("hpaListParam lists the parameters available for subsetting", {
+    params <- hpaListParam(data = hpa_histology_data)
+    expect_true(all(c("normal_tissue", "pathology") %in% names(params)))
+    expect_true("tissue" %in% names(params$normal_tissue))
+    expect_true("cell_type" %in% names(params$normal_tissue))
+    expect_true("cancer" %in% names(params$pathology))
+})
+
+test_that("hpaExport writes one xlsx file with a sheet per dataset", {
+    sub <- hpaSubset(data = hpa_histology_data, targetGene = "TP53", targetTissue = "Breast")
+    fileName <- file.path(tempdir(), "hpaanalyze_test_export_xlsx")
+    on.exit(unlink(paste0(fileName, ".xlsx")), add = TRUE)
+
+    hpaExport(data = sub, fileName = fileName, fileType = "xlsx")
+
+    expect_true(file.exists(paste0(fileName, ".xlsx")))
+    expect_setequal(openxlsx::getSheetNames(paste0(fileName, ".xlsx")), names(sub))
+})
+
+test_that("hpaExport writes one csv file per dataset", {
+    sub <- hpaSubset(data = hpa_histology_data, targetGene = "TP53", targetTissue = "Breast")
+    fileName <- file.path(tempdir(), "hpaanalyze_test_export_csv")
+    expectedFiles <- paste0(fileName, "_", names(sub), ".csv")
+    on.exit(unlink(expectedFiles), add = TRUE)
+
+    hpaExport(data = sub, fileName = fileName, fileType = "csv")
+
+    expect_true(all(file.exists(expectedFiles)))
+})
+
+test_that("hpaExport writes one tsv file per dataset", {
+    sub <- hpaSubset(data = hpa_histology_data, targetGene = "TP53", targetTissue = "Breast")
+    fileName <- file.path(tempdir(), "hpaanalyze_test_export_tsv")
+    expectedFiles <- paste0(fileName, "_", names(sub), ".tsv")
+    on.exit(unlink(expectedFiles), add = TRUE)
+
+    hpaExport(data = sub, fileName = fileName, fileType = "tsv")
+
+    expect_true(all(file.exists(expectedFiles)))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,57 @@
+test_that("gene_ensembl_convert converts gene symbols to ensembl ids", {
+    out <- gene_ensembl_convert(c("TP53", "EGFR"), "ensembl")
+    expect_equal(out, c("ENSG00000141510", "ENSG00000146648"))
+})
+
+test_that("gene_ensembl_convert converts ensembl ids to gene symbols", {
+    out <- gene_ensembl_convert(c("ENSG00000141510", "ENSG00000146648"), "gene")
+    expect_equal(out, c("TP53", "EGFR"))
+})
+
+test_that("gene_ensembl_convert leaves already-converted ids untouched", {
+    expect_equal(gene_ensembl_convert("ENSG00000141510", "ensembl"), "ENSG00000141510")
+    expect_equal(gene_ensembl_convert("TP53", "gene"), "TP53")
+})
+
+test_that("gene_ensembl_convert warns and passes through unmatched ids", {
+    expect_message(
+        out <- gene_ensembl_convert("NOTAREALGENE", "ensembl"),
+        "Couldn't find all requested genes"
+    )
+    expect_equal(out, "NOTAREALGENE")
+})
+
+test_that("version_to_xml_url builds the expected urls", {
+    expect_equal(
+        version_to_xml_url("ENSG00000131979", "latest"),
+        "https://www.proteinatlas.org/ENSG00000131979.xml"
+    )
+    expect_equal(
+        version_to_xml_url("ENSG00000131979", "v18"),
+        "https://v18.proteinatlas.org/ENSG00000131979.xml"
+    )
+})
+
+test_that("is_null_data falls back to the built-in dataset when data is NULL", {
+    expect_message(out <- is_null_data(NULL), "No data provided")
+    expect_identical(out, HPAanalyze::hpa_histology_data)
+})
+
+test_that("is_null_data passes through non-NULL data unchanged", {
+    dummy <- list(a = 1)
+    expect_silent(out <- is_null_data(dummy))
+    expect_identical(out, dummy)
+})
+
+test_that("named_vector_list_to_tibble reshapes a list of named vectors", {
+    x <- list(
+        c(a = "1", b = "2"),
+        c(a = "3", b = "4")
+    )
+    out <- named_vector_list_to_tibble(x)
+    expect_s3_class(out, "tbl_df")
+    expect_equal(names(out), c("a", "b"))
+    expect_equal(nrow(out), 2)
+    expect_equal(out$a, c("1", "3"))
+    expect_equal(out$b, c("2", "4"))
+})

--- a/tests/testthat/test-vis.R
+++ b/tests/testthat/test-vis.R
@@ -56,6 +56,31 @@ test_that("hpaVis with a single visType returns the matching hpaVis* output", {
     expect_s3_class(plot, "ggplot")
 })
 
+test_that("hpaVisTissue and hpaVisSubcell do not lock the panel to a fixed aspect ratio", {
+    # coord_equal()/coord_fixed() forces the panel's physical aspect ratio to
+    # match its data range, which can shrink the panel to a sliver and leave
+    # axis text looking oversized when the plot is embedded in a container
+    # whose shape doesn't match (e.g. one cell of hpaVis()'s gridExtra
+    # layout). Plain CoordCartesian lets the panel fill whatever space it is
+    # given instead.
+    tissuePlot <- suppressMessages(
+        hpaVisTissue(
+            data = hpa_histology_data,
+            targetGene = c("TP53", "EGFR"),
+            targetTissue = "Breast"
+        )
+    )
+    expect_false(inherits(tissuePlot$coordinates, "CoordFixed"))
+
+    subcellPlot <- suppressMessages(
+        hpaVisSubcell(
+            data = hpa_histology_data,
+            targetGene = c("TP53", "EGFR")
+        )
+    )
+    expect_false(inherits(subcellPlot$coordinates, "CoordFixed"))
+})
+
 test_that("customTheme=TRUE returns a barebone ggplot without the default theming", {
     plot <- suppressMessages(
         hpaVisTissue(

--- a/tests/testthat/test-vis.R
+++ b/tests/testthat/test-vis.R
@@ -56,13 +56,7 @@ test_that("hpaVis with a single visType returns the matching hpaVis* output", {
     expect_s3_class(plot, "ggplot")
 })
 
-test_that("hpaVisTissue and hpaVisSubcell do not lock the panel to a fixed aspect ratio", {
-    # coord_equal()/coord_fixed() forces the panel's physical aspect ratio to
-    # match its data range, which can shrink the panel to a sliver and leave
-    # axis text looking oversized when the plot is embedded in a container
-    # whose shape doesn't match (e.g. one cell of hpaVis()'s gridExtra
-    # layout). Plain CoordCartesian lets the panel fill whatever space it is
-    # given instead.
+test_that("hpaVisTissue and hpaVisSubcell render square tiles by default", {
     tissuePlot <- suppressMessages(
         hpaVisTissue(
             data = hpa_histology_data,
@@ -70,7 +64,7 @@ test_that("hpaVisTissue and hpaVisSubcell do not lock the panel to a fixed aspec
             targetTissue = "Breast"
         )
     )
-    expect_false(inherits(tissuePlot$coordinates, "CoordFixed"))
+    expect_s3_class(tissuePlot$coordinates, "CoordFixed")
 
     subcellPlot <- suppressMessages(
         hpaVisSubcell(
@@ -78,7 +72,7 @@ test_that("hpaVisTissue and hpaVisSubcell do not lock the panel to a fixed aspec
             targetGene = c("TP53", "EGFR")
         )
     )
-    expect_false(inherits(subcellPlot$coordinates, "CoordFixed"))
+    expect_s3_class(subcellPlot$coordinates, "CoordFixed")
 })
 
 test_that("customTheme=TRUE returns a barebone ggplot without the default theming", {

--- a/tests/testthat/test-vis.R
+++ b/tests/testthat/test-vis.R
@@ -64,7 +64,11 @@ test_that("hpaVisTissue and hpaVisSubcell render square tiles by default", {
             targetTissue = "Breast"
         )
     )
-    expect_s3_class(tissuePlot$coordinates, "CoordFixed")
+    # Check the public `ratio` argument coord_equal()/coord_fixed() is built
+    # from, rather than the internal S3 class name it currently produces -
+    # the latter isn't part of ggplot2's documented contract and has already
+    # changed across ggplot2 major versions.
+    expect_equal(tissuePlot$coordinates$ratio, 1)
 
     subcellPlot <- suppressMessages(
         hpaVisSubcell(
@@ -72,7 +76,7 @@ test_that("hpaVisTissue and hpaVisSubcell render square tiles by default", {
             targetGene = c("TP53", "EGFR")
         )
     )
-    expect_s3_class(subcellPlot$coordinates, "CoordFixed")
+    expect_equal(subcellPlot$coordinates$ratio, 1)
 })
 
 test_that("customTheme=TRUE returns a barebone ggplot without the default theming", {

--- a/tests/testthat/test-vis.R
+++ b/tests/testthat/test-vis.R
@@ -86,6 +86,9 @@ test_that("customTheme=TRUE returns a barebone ggplot without the default themin
     )
     expect_s3_class(plot, "ggplot")
     # the default (non-barebone) theme relabels the y axis to "Tissue / Cell";
-    # customTheme=TRUE should leave ggplot2's automatic label untouched
-    expect_equal(plot$labels$y, "tissue_cell")
+    # customTheme=TRUE should leave that relabeling off. (Not asserting the
+    # exact automatic label ggplot2 falls back to instead, since whether it's
+    # populated eagerly or only at build time is a ggplot2-version-dependent
+    # implementation detail, not something this package controls.)
+    expect_false(identical(plot$labels$y, "Tissue / Cell"))
 })

--- a/tests/testthat/test-vis.R
+++ b/tests/testthat/test-vis.R
@@ -1,0 +1,72 @@
+data("hpa_histology_data")
+
+test_that("hpaVisTissue returns a ggplot object", {
+    plot <- suppressMessages(
+        hpaVisTissue(
+            data = hpa_histology_data,
+            targetGene = c("TP53", "EGFR"),
+            targetTissue = c("Breast", "Cerebellum")
+        )
+    )
+    expect_s3_class(plot, "ggplot")
+})
+
+test_that("hpaVisTissue warns when targetCellType is not specified", {
+    expect_message(
+        hpaVisTissue(
+            data = hpa_histology_data,
+            targetGene = c("TP53", "EGFR"),
+            targetTissue = "Breast"
+        ),
+        "targetCellType"
+    )
+})
+
+test_that("hpaVisPatho returns a ggplot object", {
+    plot <- suppressMessages(
+        hpaVisPatho(
+            data = hpa_histology_data,
+            targetGene = c("TP53", "EGFR"),
+            targetCancer = c("breast cancer", "glioma")
+        )
+    )
+    expect_s3_class(plot, "ggplot")
+})
+
+test_that("hpaVisSubcell returns a ggplot object", {
+    plot <- suppressMessages(
+        hpaVisSubcell(
+            data = hpa_histology_data,
+            targetGene = c("TP53", "EGFR")
+        )
+    )
+    expect_s3_class(plot, "ggplot")
+})
+
+test_that("hpaVis with a single visType returns the matching hpaVis* output", {
+    plot <- suppressMessages(
+        hpaVis(
+            data = hpa_histology_data,
+            targetGene = c("TP53", "EGFR"),
+            targetTissue = "Breast",
+            targetCellType = NULL,
+            visType = "Tissue"
+        )
+    )
+    expect_s3_class(plot, "ggplot")
+})
+
+test_that("customTheme=TRUE returns a barebone ggplot without the default theming", {
+    plot <- suppressMessages(
+        hpaVisTissue(
+            data = hpa_histology_data,
+            targetGene = c("TP53", "EGFR"),
+            targetTissue = "Breast",
+            customTheme = TRUE
+        )
+    )
+    expect_s3_class(plot, "ggplot")
+    # the default (non-barebone) theme relabels the y axis to "Tissue / Cell";
+    # customTheme=TRUE should leave ggplot2's automatic label untouched
+    expect_equal(plot$labels$y, "tissue_cell")
+})

--- a/tests/testthat/test-xml.R
+++ b/tests/testthat/test-xml.R
@@ -1,0 +1,51 @@
+# These tests use a real HPA xml file bundled as a test fixture (also used,
+# unmodified, by the "offline xml" vignette) so they can run without network
+# access.
+ccnb1xml <- xml2::read_xml(test_path("testdata", "ENSG00000134057.xml"))
+
+test_that("hpaXmlProtClass extracts protein class information", {
+    out <- hpaXmlProtClass(ccnb1xml)
+    expect_s3_class(out, "tbl_df")
+    expect_equal(names(out), c("source", "id", "parent_id", "name"))
+    expect_true(nrow(out) > 0)
+    expect_true("Transporters" %in% out$name)
+})
+
+test_that("hpaXmlTissueExprSum extracts a summary and an image url tibble", {
+    out <- hpaXmlTissueExprSum(ccnb1xml)
+    expect_type(out, "list")
+    expect_type(out$summary, "character")
+    expect_s3_class(out$img, "tbl_df")
+    expect_equal(names(out$img), c("tissue", "imageUrl"))
+    expect_true(nrow(out$img) > 0)
+})
+
+test_that("hpaXmlAntibody extracts antibody information", {
+    out <- hpaXmlAntibody(ccnb1xml)
+    expect_s3_class(out, "tbl_df")
+    expect_true(all(c("id", "releaseDate", "releaseVersion") %in% names(out)))
+    expect_true(nrow(out) > 0)
+})
+
+test_that("hpaXmlTissueExpr extracts one tibble of samples per antibody", {
+    out <- hpaXmlTissueExpr(ccnb1xml)
+    expect_type(out, "list")
+    expect_true(length(out) > 0)
+    expect_s3_class(out[[1]], "tbl_df")
+    expect_true(all(
+        c("patientId", "age", "sex", "staining", "intensity", "quantity", "location") %in%
+            names(out[[1]])
+    ))
+})
+
+test_that("hpaXml dispatches to the requested extraction functions", {
+    out <- hpaXml(ccnb1xml, extractType = c("ProtClass", "Antibody"))
+    expect_equal(names(out), c("ProtClass", "Antibody"))
+    expect_s3_class(out$ProtClass, "tbl_df")
+    expect_s3_class(out$Antibody, "tbl_df")
+})
+
+test_that("hpaXml accepts an already-imported xml_document as input", {
+    out <- hpaXml(ccnb1xml, extractType = "ProtClass")
+    expect_equal(names(out), "ProtClass")
+})

--- a/tests/testthat/testdata/ENSG00000134057.xml
+++ b/tests/testthat/testdata/ENSG00000134057.xml
@@ -1,0 +1,10077 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proteinAtlas xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://v18.proteinatlas.org/download/proteinatlas.xsd" schemaVersion="2.5">
+	<entry version="18" url="http://v18.proteinatlas.org/ENSG00000134057">
+		<name>CCNB1</name>
+		<synonym>CCNB</synonym>
+		<identifier id="ENSG00000134057" db="Ensembl" version="88.38">
+			<xref id="P14635" db="Uniprot/SWISSPROT"/>
+		</identifier>
+		<proteinClasses>
+			<proteinClass source="TCDB" id="Ja" parent_id="" name="Transporters"/>
+			<proteinClass source="TCDB" id="Jb" parent_id="Ja" name="Transporter channels and pores"/>
+			<proteinClass source="SPOCTOPUS" id="Mi" parent_id="" name="SPOCTOPUS predicted membrane proteins"/>
+			<proteinClass source="HPA" id="Za" parent_id="" name="Predicted intracellular proteins"/>
+			<proteinClass source="Plasma Proteome Database" id="Pp" parent_id="" name="Plasma proteins"/>
+			<proteinClass source="" id="Ca" parent_id="" name="Cancer-related genes"/>
+			<proteinClass source="Plasma Proteome Institute" id="Cb" parent_id="Ca" name="Candidate cancer biomarkers"/>
+			<proteinClass source="UniProt" id="Ua" parent_id="" name="UniProt - Evidence at protein level"/>
+			<proteinClass source="Kim et al 2014" id="Ea" parent_id="" name="Protein evidence (Kim et al 2014)"/>
+			<proteinClass source="Ezkurdia et al 2014" id="Eb" parent_id="" name="Protein evidence (Ezkurdia et al 2014)"/>
+		</proteinClasses>
+		<proteinEvidence evidence="Evidence at protein level">
+			<evidence source="HPA" evidence="Evidence at protein level"/>
+			<evidence source="MS" evidence="Evidence at protein level"/>
+			<evidence source="UniProt" evidence="Evidence at protein level"/>
+		</proteinEvidence>
+		<tissueExpression source="HPA" technology="IHC" assayType="tissue">
+			<summary type="tissue"><![CDATA[Cytoplasmic expression in proliferating cells.]]></summary>
+			<verification type="reliability" description="Antibody staining mainly consistent with RNA expression data. ">enhanced</verification>
+			<image imageType="selected">
+				<tissue>cerebral cortex</tissue>
+				<imageUrl>http://v18.proteinatlas.org/images/3804/10580_B_8_5_rna_selected.jpg</imageUrl>
+			</image>
+			<image imageType="selected">
+				<tissue>lymph node</tissue>
+				<imageUrl>http://v18.proteinatlas.org/images/3804/10580_A_8_8_rna_selected.jpg</imageUrl>
+			</image>
+			<image imageType="selected">
+				<tissue>liver</tissue>
+				<imageUrl>http://v18.proteinatlas.org/images/3804/10580_A_7_4_rna_selected.jpg</imageUrl>
+			</image>
+			<image imageType="selected">
+				<tissue>colon</tissue>
+				<imageUrl>http://v18.proteinatlas.org/images/3804/10580_A_9_3_rna_selected.jpg</imageUrl>
+			</image>
+			<image imageType="selected">
+				<tissue>kidney</tissue>
+				<imageUrl>http://v18.proteinatlas.org/images/3804/10580_A_9_5_rna_selected.jpg</imageUrl>
+			</image>
+			<image imageType="selected">
+				<tissue>testis</tissue>
+				<imageUrl>http://v18.proteinatlas.org/images/3804/10580_A_4_6_rna_selected.jpg</imageUrl>
+			</image>
+			<image imageType="selected">
+				<tissue>placenta</tissue>
+				<imageUrl>http://v18.proteinatlas.org/images/3804/10580_A_2_7_rna_selected.jpg</imageUrl>
+			</image>
+			<data>
+				<tissue>adrenal gland</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>appendix</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>lymphoid tissue</cellType>
+					<level type="expression">low</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>bone marrow</tissue>
+				<level type="expression">high</level>
+				<tissueCell>
+					<cellType>hematopoietic cells</cellType>
+					<level type="expression">high</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>breast</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>adipocytes</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>myoepithelial cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>bronchus</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>respiratory epithelial cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>caudate</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>glial cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>neuronal cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>cerebellum</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>cells in granular layer</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>cells in molecular layer</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>Purkinje cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>cerebral cortex</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>endothelial cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>glial cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>neuronal cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>neuropil</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>cervix, uterine</tissue>
+				<level type="expression">low</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">low</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>squamous epithelial cells</cellType>
+					<level type="expression">low</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>colon</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>endothelial cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>peripheral nerve/ganglion</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>duodenum</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>endometrium</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>cells in endometrial stroma</cellType>
+					<level type="expression">low</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>endometrium</tissue>
+				<level type="expression">low</level>
+				<tissueCell>
+					<cellType>cells in endometrial stroma</cellType>
+					<level type="expression">low</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">low</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>epididymis</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>esophagus</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>squamous epithelial cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>fallopian tube</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>gallbladder</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>heart muscle</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>myocytes</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>hippocampus</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>glial cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>neuronal cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>kidney</tissue>
+				<level type="expression">low</level>
+				<tissueCell>
+					<cellType>cells in glomeruli</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>cells in tubules</cellType>
+					<level type="expression">low</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>liver</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>bile duct cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>hepatocytes</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>lung</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>macrophages</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>pneumocytes</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>lymph node</tissue>
+				<level type="expression">high</level>
+				<tissueCell>
+					<cellType>germinal center cells</cellType>
+					<level type="expression">high</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>non-germinal center cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>nasopharynx</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>respiratory epithelial cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>oral mucosa</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>squamous epithelial cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>ovary</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>follicle cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>ovarian stroma cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>pancreas</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>exocrine glandular cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>islets of Langerhans</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>parathyroid gland</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>placenta</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>decidual cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>trophoblastic cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>prostate</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>rectum</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>salivary gland</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>seminal vesicle</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>skeletal muscle</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>myocytes</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>skin</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>fibroblasts</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>keratinocytes</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>Langerhans</cellType>
+					<level type="expression">low</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>melanocytes</cellType>
+					<level type="expression">low</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>skin</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>epidermal cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>small intestine</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>smooth muscle</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>smooth muscle cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>soft tissue</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>adipocytes</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>chondrocytes</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>fibroblasts</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>peripheral nerve</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>soft tissue</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>adipocytes</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>fibroblasts</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>peripheral nerve</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>spleen</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>cells in red pulp</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>cells in white pulp</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>stomach</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>stomach</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>testis</tissue>
+				<level type="expression">high</level>
+				<tissueCell>
+					<cellType>cells in seminiferous ducts</cellType>
+					<level type="expression">high</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>Leydig cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>thyroid gland</tissue>
+				<level type="expression">not detected</level>
+				<tissueCell>
+					<cellType>glandular cells</cellType>
+					<level type="expression">not detected</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>tonsil</tissue>
+				<level type="expression">high</level>
+				<tissueCell>
+					<cellType>germinal center cells</cellType>
+					<level type="expression">high</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>non-germinal center cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+				<tissueCell>
+					<cellType>squamous epithelial cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>urinary bladder</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>urothelial cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+			<data>
+				<tissue>vagina</tissue>
+				<level type="expression">medium</level>
+				<tissueCell>
+					<cellType>squamous epithelial cells</cellType>
+					<level type="expression">medium</level>
+				</tissueCell>
+			</data>
+		</tissueExpression>
+		<cellExpression source="HPA" technology="ICC/IF">
+			<summary><![CDATA[Localized to the cytosol.]]></summary>
+			<verification type="reliability">enhanced</verification>
+			<image imageType="selected">
+				<imageUrl>http://v18.proteinatlas.org/images/30741/793_A6_1_selected.jpg</imageUrl>
+			</image>
+			<data>
+				<location status="main" GOId="GO:0005829">cytosol</location>
+			</data>
+		</cellExpression>
+		<rnaExpression source="HPA" technology="RNAseq">
+			<rnaTissueCategory description="Detected in 2-37 tissues but not elevated in any tissue">Mixed</rnaTissueCategory>
+			<data>
+				<cellLine>A-431</cellLine>
+				<level type="abundance" tpm="407.3">High</level>
+			</data>
+			<data>
+				<cellLine>A549</cellLine>
+				<level type="abundance" tpm="286.1">High</level>
+			</data>
+			<data>
+				<cellLine>AF22</cellLine>
+				<level type="abundance" tpm="418.9">High</level>
+			</data>
+			<data>
+				<cellLine>AN3-CA</cellLine>
+				<level type="abundance" tpm="352.2">High</level>
+			</data>
+			<data>
+				<cellLine>ASC diff</cellLine>
+				<level type="abundance" tpm="15.1">Low</level>
+			</data>
+			<data>
+				<cellLine>ASC TERT1</cellLine>
+				<level type="abundance" tpm="25.8">Medium</level>
+			</data>
+			<data>
+				<cellLine>BEWO</cellLine>
+				<level type="abundance" tpm="963.9">High</level>
+			</data>
+			<data>
+				<cellLine>BJ</cellLine>
+				<level type="abundance" tpm="170.2">High</level>
+			</data>
+			<data>
+				<cellLine>BJ hTERT+</cellLine>
+				<level type="abundance" tpm="122.0">High</level>
+			</data>
+			<data>
+				<cellLine>BJ hTERT+ SV40 Large T+</cellLine>
+				<level type="abundance" tpm="483.8">High</level>
+			</data>
+			<data>
+				<cellLine>BJ hTERT+ SV40 Large T+ RasG12V</cellLine>
+				<level type="abundance" tpm="424.7">High</level>
+			</data>
+			<data>
+				<cellLine>CACO-2</cellLine>
+				<level type="abundance" tpm="389.0">High</level>
+			</data>
+			<data>
+				<cellLine>CAPAN-2</cellLine>
+				<level type="abundance" tpm="375.5">High</level>
+			</data>
+			<data>
+				<cellLine>Daudi</cellLine>
+				<level type="abundance" tpm="203.5">High</level>
+			</data>
+			<data>
+				<cellLine>EFO-21</cellLine>
+				<level type="abundance" tpm="225.2">High</level>
+			</data>
+			<data>
+				<cellLine>fHDF/TERT166</cellLine>
+				<level type="abundance" tpm="145.2">High</level>
+			</data>
+			<data>
+				<cellLine>HaCaT</cellLine>
+				<level type="abundance" tpm="253.3">High</level>
+			</data>
+			<data>
+				<cellLine>HAP1</cellLine>
+				<level type="abundance" tpm="444.7">High</level>
+			</data>
+			<data>
+				<cellLine>HBEC3-KT</cellLine>
+				<level type="abundance" tpm="315.8">High</level>
+			</data>
+			<data>
+				<cellLine>HBF TERT88</cellLine>
+				<level type="abundance" tpm="559.2">High</level>
+			</data>
+			<data>
+				<cellLine>HDLM-2</cellLine>
+				<level type="abundance" tpm="261.0">High</level>
+			</data>
+			<data>
+				<cellLine>HEK 293</cellLine>
+				<level type="abundance" tpm="195.7">High</level>
+			</data>
+			<data>
+				<cellLine>HEL</cellLine>
+				<level type="abundance" tpm="162.2">High</level>
+			</data>
+			<data>
+				<cellLine>HeLa</cellLine>
+				<level type="abundance" tpm="175.9">High</level>
+			</data>
+			<data>
+				<cellLine>Hep G2</cellLine>
+				<level type="abundance" tpm="223.0">High</level>
+			</data>
+			<data>
+				<cellLine>HHSteC</cellLine>
+				<level type="abundance" tpm="5.7">Low</level>
+			</data>
+			<data>
+				<cellLine>HL-60</cellLine>
+				<level type="abundance" tpm="126.2">High</level>
+			</data>
+			<data>
+				<cellLine>HMC-1</cellLine>
+				<level type="abundance" tpm="174.5">High</level>
+			</data>
+			<data>
+				<cellLine>HSkMC</cellLine>
+				<level type="abundance" tpm="12.0">Low</level>
+			</data>
+			<data>
+				<cellLine>hTCEpi</cellLine>
+				<level type="abundance" tpm="19.8">Low</level>
+			</data>
+			<data>
+				<cellLine>hTEC/SVTERT24-B</cellLine>
+				<level type="abundance" tpm="299.2">High</level>
+			</data>
+			<data>
+				<cellLine>hTERT-HME1</cellLine>
+				<level type="abundance" tpm="158.7">High</level>
+			</data>
+			<data>
+				<cellLine>HUVEC TERT2</cellLine>
+				<level type="abundance" tpm="234.9">High</level>
+			</data>
+			<data>
+				<cellLine>K-562</cellLine>
+				<level type="abundance" tpm="199.0">High</level>
+			</data>
+			<data>
+				<cellLine>Karpas-707</cellLine>
+				<level type="abundance" tpm="157.8">High</level>
+			</data>
+			<data>
+				<cellLine>LHCN-M2</cellLine>
+				<level type="abundance" tpm="357.8">High</level>
+			</data>
+			<data>
+				<cellLine>MCF7</cellLine>
+				<level type="abundance" tpm="338.7">High</level>
+			</data>
+			<data>
+				<cellLine>MOLT-4</cellLine>
+				<level type="abundance" tpm="175.7">High</level>
+			</data>
+			<data>
+				<cellLine>NB-4</cellLine>
+				<level type="abundance" tpm="119.3">High</level>
+			</data>
+			<data>
+				<cellLine>NTERA-2</cellLine>
+				<level type="abundance" tpm="236.9">High</level>
+			</data>
+			<data>
+				<cellLine>PC-3</cellLine>
+				<level type="abundance" tpm="183.7">High</level>
+			</data>
+			<data>
+				<cellLine>REH</cellLine>
+				<level type="abundance" tpm="207.6">High</level>
+			</data>
+			<data>
+				<cellLine>RH-30</cellLine>
+				<level type="abundance" tpm="296.2">High</level>
+			</data>
+			<data>
+				<cellLine>RPMI-8226</cellLine>
+				<level type="abundance" tpm="203.2">High</level>
+			</data>
+			<data>
+				<cellLine>RPTEC TERT1</cellLine>
+				<level type="abundance" tpm="144.4">High</level>
+			</data>
+			<data>
+				<cellLine>RT4</cellLine>
+				<level type="abundance" tpm="135.1">High</level>
+			</data>
+			<data>
+				<cellLine>SCLC-21H</cellLine>
+				<level type="abundance" tpm="253.3">High</level>
+			</data>
+			<data>
+				<cellLine>SH-SY5Y</cellLine>
+				<level type="abundance" tpm="143.6">High</level>
+			</data>
+			<data>
+				<cellLine>SiHa</cellLine>
+				<level type="abundance" tpm="367.9">High</level>
+			</data>
+			<data>
+				<cellLine>SK-BR-3</cellLine>
+				<level type="abundance" tpm="120.6">High</level>
+			</data>
+			<data>
+				<cellLine>SK-MEL-30</cellLine>
+				<level type="abundance" tpm="117.3">High</level>
+			</data>
+			<data>
+				<cellLine>T-47d</cellLine>
+				<level type="abundance" tpm="289.7">High</level>
+			</data>
+			<data>
+				<cellLine>THP-1</cellLine>
+				<level type="abundance" tpm="110.6">High</level>
+			</data>
+			<data>
+				<cellLine>TIME</cellLine>
+				<level type="abundance" tpm="97.4">High</level>
+			</data>
+			<data>
+				<cellLine>U-138 MG</cellLine>
+				<level type="abundance" tpm="113.6">High</level>
+			</data>
+			<data>
+				<cellLine>U-2 OS</cellLine>
+				<level type="abundance" tpm="390.1">High</level>
+			</data>
+			<data>
+				<cellLine>U-2197</cellLine>
+				<level type="abundance" tpm="195.3">High</level>
+			</data>
+			<data>
+				<cellLine>U-251 MG</cellLine>
+				<level type="abundance" tpm="422.2">High</level>
+			</data>
+			<data>
+				<cellLine>U-266/70</cellLine>
+				<level type="abundance" tpm="83.4">High</level>
+			</data>
+			<data>
+				<cellLine>U-266/84</cellLine>
+				<level type="abundance" tpm="151.2">High</level>
+			</data>
+			<data>
+				<cellLine>U-698</cellLine>
+				<level type="abundance" tpm="272.2">High</level>
+			</data>
+			<data>
+				<cellLine>U-87 MG</cellLine>
+				<level type="abundance" tpm="156.2">High</level>
+			</data>
+			<data>
+				<cellLine>U-937</cellLine>
+				<level type="abundance" tpm="214.8">High</level>
+			</data>
+			<data>
+				<cellLine>WM-115</cellLine>
+				<level type="abundance" tpm="356.9">High</level>
+			</data>
+			<data>
+				<tissue>adipose tissue</tissue>
+				<level type="abundance" tpm="4.5">Low</level>
+			</data>
+			<data>
+				<tissue>adrenal gland</tissue>
+				<level type="abundance" tpm="5.1">Low</level>
+			</data>
+			<data>
+				<tissue>appendix</tissue>
+				<level type="abundance" tpm="34.9">Medium</level>
+			</data>
+			<data>
+				<tissue>bone marrow</tissue>
+				<level type="abundance" tpm="32.7">Medium</level>
+			</data>
+			<data>
+				<tissue>breast</tissue>
+				<level type="abundance" tpm="11.8">Medium</level>
+			</data>
+			<data>
+				<tissue>cerebral cortex</tissue>
+				<level type="abundance" tpm="7.7">Low</level>
+			</data>
+			<data>
+				<tissue>cervix, uterine</tissue>
+				<level type="abundance" tpm="8.9">Low</level>
+			</data>
+			<data>
+				<tissue>colon</tissue>
+				<level type="abundance" tpm="22.0">Medium</level>
+			</data>
+			<data>
+				<tissue>duodenum</tissue>
+				<level type="abundance" tpm="21.0">Medium</level>
+			</data>
+			<data>
+				<tissue>endometrium 1</tissue>
+				<level type="abundance" tpm="13.3">Medium</level>
+			</data>
+			<data>
+				<tissue>epididymis</tissue>
+				<level type="abundance" tpm="6.5">Low</level>
+			</data>
+			<data>
+				<tissue>esophagus</tissue>
+				<level type="abundance" tpm="25.5">Medium</level>
+			</data>
+			<data>
+				<tissue>fallopian tube</tissue>
+				<level type="abundance" tpm="12.2">Medium</level>
+			</data>
+			<data>
+				<tissue>gallbladder</tissue>
+				<level type="abundance" tpm="6.0">Low</level>
+			</data>
+			<data>
+				<tissue>heart muscle</tissue>
+				<level type="abundance" tpm="1.8">Low</level>
+			</data>
+			<data>
+				<tissue>kidney</tissue>
+				<level type="abundance" tpm="5.1">Low</level>
+			</data>
+			<data>
+				<tissue>liver</tissue>
+				<level type="abundance" tpm="2.2">Low</level>
+			</data>
+			<data>
+				<tissue>lung</tissue>
+				<level type="abundance" tpm="5.5">Low</level>
+			</data>
+			<data>
+				<tissue>lymph node</tissue>
+				<level type="abundance" tpm="65.5">High</level>
+			</data>
+			<data>
+				<tissue>ovary</tissue>
+				<level type="abundance" tpm="5.5">Low</level>
+			</data>
+			<data>
+				<tissue>pancreas</tissue>
+				<level type="abundance" tpm="0.7">Not detected</level>
+			</data>
+			<data>
+				<tissue>parathyroid gland</tissue>
+				<level type="abundance" tpm="6.1">Low</level>
+			</data>
+			<data>
+				<tissue>placenta</tissue>
+				<level type="abundance" tpm="30.0">Medium</level>
+			</data>
+			<data>
+				<tissue>prostate</tissue>
+				<level type="abundance" tpm="5.9">Low</level>
+			</data>
+			<data>
+				<tissue>rectum</tissue>
+				<level type="abundance" tpm="33.3">Medium</level>
+			</data>
+			<data>
+				<tissue>salivary gland</tissue>
+				<level type="abundance" tpm="1.7">Low</level>
+			</data>
+			<data>
+				<tissue>seminal vesicle</tissue>
+				<level type="abundance" tpm="5.3">Low</level>
+			</data>
+			<data>
+				<tissue>skeletal muscle</tissue>
+				<level type="abundance" tpm="1.1">Low</level>
+			</data>
+			<data>
+				<tissue>skin 1</tissue>
+				<level type="abundance" tpm="17.3">Medium</level>
+			</data>
+			<data>
+				<tissue>small intestine</tissue>
+				<level type="abundance" tpm="22.0">Medium</level>
+			</data>
+			<data>
+				<tissue>smooth muscle</tissue>
+				<level type="abundance" tpm="20.8">Medium</level>
+			</data>
+			<data>
+				<tissue>spleen</tissue>
+				<level type="abundance" tpm="9.9">Low</level>
+			</data>
+			<data>
+				<tissue>stomach 1</tissue>
+				<level type="abundance" tpm="10.2">Medium</level>
+			</data>
+			<data>
+				<tissue>testis</tissue>
+				<level type="abundance" tpm="60.0">High</level>
+			</data>
+			<data>
+				<tissue>thyroid gland</tissue>
+				<level type="abundance" tpm="14.3">Medium</level>
+			</data>
+			<data>
+				<tissue>tonsil</tissue>
+				<level type="abundance" tpm="62.1">High</level>
+			</data>
+			<data>
+				<tissue>urinary bladder</tissue>
+				<level type="abundance" tpm="14.3">Medium</level>
+			</data>
+		</rnaExpression>
+		<antibody id="CAB000115" releaseVersion="1.2" releaseDate="2006-03-13">
+			<antigenSequence></antigenSequence>
+			<antibodyTargetWeights>
+				<weight value="48.3" unit="kDa"/>
+				<weight value="44.9" unit="kDa"/>
+				<weight value="44.1" unit="kDa"/>
+				<weight value="26.8" unit="kDa"/>
+				<weight value="21.5" unit="kDa"/>
+			</antibodyTargetWeights>
+			<tissueExpression source="HPA" technology="IHC" assayType="tissue">
+				<summary type="tissue"><![CDATA[Strong cytoplasmic positivity in proliferating cells. Remaining normal cells were negative.]]></summary>
+				<validation type="RNAConsistency">Mainly not consistent with RNA expression data</validation>
+				<validation type="literatureConformity">Consistent with extensive gene/protein characterization data</validation>
+				<image imageType="selected" description="Immunohistochemical staining of human lymph node shows strong cytoplasmic positivity in reaction center cells.">
+					<imageUrl>http://v18.proteinatlas.org/images/115/ihc_selected.jpg</imageUrl>
+				</image>
+				<data>
+					<tissue>adrenal gland</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>53</age>
+						<patientId>1653</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Adrenal gland" snomedCode="T-93000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_4_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>60</age>
+						<patientId>1721</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Adrenal gland" snomedCode="T-93000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_6_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>57</age>
+						<patientId>1725</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Adrenal gland" snomedCode="T-93000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_5_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>appendix</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>lymphoid tissue</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>7</age>
+						<patientId>598</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Appendix" snomedCode="T-66000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_2_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>82</age>
+						<patientId>666</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Appendix" snomedCode="T-66000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_1_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>36</age>
+						<patientId>2637</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Appendix" snomedCode="T-66000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_3_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>bone marrow</tissue>
+					<tissueCell>
+						<cellType>hematopoietic cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>75</age>
+						<patientId>2667</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Bone marrow" snomedCode="T-06000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_5_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>72</age>
+						<patientId>2671</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Bone marrow" snomedCode="T-06000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_6_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>breast</tissue>
+					<tissueCell>
+						<cellType>adipocytes</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>myoepithelial cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>45</age>
+						<patientId>1447</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_2_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>44</age>
+						<patientId>1452</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_3_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>bronchus</tissue>
+					<tissueCell>
+						<cellType>respiratory epithelial cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>57</age>
+						<patientId>1932</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Bronchus" snomedCode="T-26000"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_6_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>caudate</tissue>
+					<tissueCell>
+						<cellType>glial cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>neuronal cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>45</age>
+						<patientId>2521</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Lateral ventricle wall" snomedCode="T-X1600"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_7_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>54</age>
+						<patientId>2523</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Lateral ventricle wall" snomedCode="T-X1600"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_8_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>19</age>
+						<patientId>2524</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Lateral ventricle wall" snomedCode="T-X1600"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_9_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>cerebellum</tissue>
+					<tissueCell>
+						<cellType>cells in granular layer</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>cells in molecular layer</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>Purkinje cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>45</age>
+						<patientId>2521</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cerebellum" snomedCode="T-X6000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_7_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>54</age>
+						<patientId>2523</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cerebellum" snomedCode="T-X6000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_8_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>19</age>
+						<patientId>2524</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cerebellum" snomedCode="T-X6000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_9_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>cerebral cortex</tissue>
+					<tissueCell>
+						<cellType>endothelial cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>glial cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>neuronal cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>neuropil</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>45</age>
+						<patientId>2521</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cerebral cortex" snomedCode="T-X2020"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_7_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>54</age>
+						<patientId>2523</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cerebral cortex" snomedCode="T-X2020"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_8_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>19</age>
+						<patientId>2524</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cerebral cortex" snomedCode="T-X2020"/>
+								<snomed tissueDescription="Hippocampus" snomedCode="T-X2570"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_9_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>cervix, uterine</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>squamous epithelial cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>82</age>
+						<patientId>1401</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_7_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>70</age>
+						<patientId>1657</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_9_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>53</age>
+						<patientId>1681</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_8_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>colon</tissue>
+					<tissueCell>
+						<cellType>endothelial cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>peripheral nerve/ganglion</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>52</age>
+						<patientId>63</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_9_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>62</age>
+						<patientId>287</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_8_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>78</age>
+						<patientId>368</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_7_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>duodenum</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>84</age>
+						<patientId>139</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Stomach, lower" snomedCode="T-63700"/>
+								<snomed tissueDescription="Duodenum" snomedCode="T-64300"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_7_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>75</age>
+						<patientId>1098</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Duodenum" snomedCode="T-64300"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_9_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>79</age>
+						<patientId>2650</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+								<snomed tissueDescription="Duodenum" snomedCode="T-64300"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_8_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>endometrium 1</tissue>
+					<tissueCell>
+						<cellType>cells in endometrial stroma</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>36</age>
+						<patientId>1481</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_6_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>35</age>
+						<patientId>1728</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_4_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>36</age>
+						<patientId>1733</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_5_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>endometrium 2</tissue>
+					<tissueCell>
+						<cellType>cells in endometrial stroma</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>55</age>
+						<patientId>1339</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Neoplasm, benign, NOS" snomedCode="M-80000"/>
+								<snomed tissueDescription="Uterus" snomedCode="T-82000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_1_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>82</age>
+						<patientId>1401</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_3_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>52</age>
+						<patientId>1476</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_2_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>epididymis</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>77</age>
+						<patientId>758</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Epididymis" snomedCode="T-79100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_2_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>23</age>
+						<patientId>1101</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Epididymis" snomedCode="T-79100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_3_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>32</age>
+						<patientId>2718</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Epididymis" snomedCode="T-79100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_1_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>esophagus</tissue>
+					<tissueCell>
+						<cellType>squamous epithelial cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>65</age>
+						<patientId>1729</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Esophagus" snomedCode="T-62000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_4_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>61</age>
+						<patientId>1924</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Esophagus" snomedCode="T-62000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_6_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>70</age>
+						<patientId>1945</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Esophagus" snomedCode="T-62000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_5_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>fallopian tube</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>42</age>
+						<patientId>505</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Fallopian tube" snomedCode="T-86100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_8_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>51</age>
+						<patientId>531</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Fallopian tube" snomedCode="T-86100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_9_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>67</age>
+						<patientId>826</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Fallopian tube" snomedCode="T-86100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_7_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>gallbladder</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>48</age>
+						<patientId>554</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Gallbladder" snomedCode="T-57000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_4_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>58</age>
+						<patientId>631</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Gallbladder" snomedCode="T-57000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_6_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>59</age>
+						<patientId>969</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Gallbladder" snomedCode="T-57000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_5_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>heart muscle</tissue>
+					<tissueCell>
+						<cellType>myocytes</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>45</age>
+						<patientId>2521</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Heart" snomedCode="T-32000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_4_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>54</age>
+						<patientId>2523</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Heart" snomedCode="T-32000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_5_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>19</age>
+						<patientId>2524</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Heart" snomedCode="T-32000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_6_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>hippocampus</tissue>
+					<tissueCell>
+						<cellType>glial cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>neuronal cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>45</age>
+						<patientId>2521</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Hippocampus" snomedCode="T-X2570"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_7_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>54</age>
+						<patientId>2523</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Hippocampus" snomedCode="T-X2570"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_8_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>19</age>
+						<patientId>2524</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Hippocampus" snomedCode="T-X2570"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_9_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>kidney</tissue>
+					<tissueCell>
+						<cellType>cells in glomeruli</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>cells in tubules</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>61</age>
+						<patientId>443</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_9_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>36</age>
+						<patientId>924</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_8_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>52</age>
+						<patientId>1263</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_7_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>liver</tissue>
+					<tissueCell>
+						<cellType>bile duct cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>hepatocytes</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>49</age>
+						<patientId>140</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_8_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>35</age>
+						<patientId>548</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_7_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>27</age>
+						<patientId>667</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_9_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>lung</tissue>
+					<tissueCell>
+						<cellType>macrophages</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>pneumocytes</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>75</age>
+						<patientId>496</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_1_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>61</age>
+						<patientId>705</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_2_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>lymph node</tissue>
+					<tissueCell>
+						<cellType>germinal center cells</cellType>
+						<level type="staining">medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>non-germinal center cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>62</age>
+						<patientId>121</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_8_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>55</age>
+						<patientId>634</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_7_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>54</age>
+						<patientId>966</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_9_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>nasopharynx</tissue>
+					<tissueCell>
+						<cellType>respiratory epithelial cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>13</age>
+						<patientId>2249</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Nasopharynx" snomedCode="T-23000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_7_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>78</age>
+						<patientId>2630</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Nasopharynx" snomedCode="T-23000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_8_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>63</age>
+						<patientId>2692</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Nasopharynx" snomedCode="T-23000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_9_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>oral mucosa</tissue>
+					<tissueCell>
+						<cellType>squamous epithelial cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>52</age>
+						<patientId>48</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Oral tissue" snomedCode="T-51000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_9_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>79</age>
+						<patientId>340</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Oral tissue" snomedCode="T-51000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_7_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>69</age>
+						<patientId>623</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Oral tissue" snomedCode="T-51000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_8_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>ovary</tissue>
+					<tissueCell>
+						<cellType>follicle cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>ovarian stroma cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>59</age>
+						<patientId>120</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_5_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>54</age>
+						<patientId>238</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_4_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>32</age>
+						<patientId>622</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_6_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>pancreas</tissue>
+					<tissueCell>
+						<cellType>exocrine glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>islets of Langerhans</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>77</age>
+						<patientId>195</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_1_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>59</age>
+						<patientId>969</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_3_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>79</age>
+						<patientId>2650</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+								<snomed tissueDescription="Duodenum" snomedCode="T-64300"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_2_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>parathyroid gland</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>29</age>
+						<patientId>8</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Parathyroid gland" snomedCode="T-97000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_3_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>85</age>
+						<patientId>42</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Parathyroid gland" snomedCode="T-97000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_2_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>70</age>
+						<patientId>72</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Parathyroid gland" snomedCode="T-97000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_1_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>placenta</tissue>
+					<tissueCell>
+						<cellType>decidual cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>trophoblastic cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>34</age>
+						<patientId>143</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Placenta" snomedCode="T-88100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_1_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>31</age>
+						<patientId>337</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Placenta" snomedCode="T-88100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_2_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>30</age>
+						<patientId>473</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Placenta" snomedCode="T-88100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_3_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>prostate</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>65</age>
+						<patientId>78</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_2_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>68</age>
+						<patientId>613</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_3_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>64</age>
+						<patientId>1938</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_1_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>rectum</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>77</age>
+						<patientId>222</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Rectum" snomedCode="T-68000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_6_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>86</age>
+						<patientId>792</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Rectum" snomedCode="T-68000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_5_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>46</age>
+						<patientId>1876</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Rectum" snomedCode="T-68000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_4_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>salivary gland</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>62</age>
+						<patientId>1505</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Salivary gland" snomedCode="T-55100"/>
+								<snomed tissueDescription="Peripheral nerve tissue" snomedCode="T-X0500"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_1_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>55</age>
+						<patientId>1973</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Salivary gland" snomedCode="T-55100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_3_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>seminal vesicle</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>63</age>
+						<patientId>472</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Seminal veicle" snomedCode="T-77500"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_9_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>60</age>
+						<patientId>756</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Seminal veicle" snomedCode="T-77500"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_8_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>skeletal muscle</tissue>
+					<tissueCell>
+						<cellType>myocytes</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>62</age>
+						<patientId>1505</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Skeletal muscle" snomedCode="T-13000"/>
+								<snomed tissueDescription="Salivary gland" snomedCode="T-55100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_1_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>71</age>
+						<patientId>1711</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Skeletal muscle" snomedCode="T-13000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_2_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>37</age>
+						<patientId>1889</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Skeletal muscle" snomedCode="T-13000"/>
+								<snomed tissueDescription="Parathyroid gland" snomedCode="T-97000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_3_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>skin 1</tissue>
+					<tissueCell>
+						<cellType>fibroblasts</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>keratinocytes</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>Langerhans</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>melanocytes</cellType>
+						<level type="staining">medium</level>
+						<level type="intensity">Moderate</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>90</age>
+						<patientId>1692</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_8_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>86</age>
+						<patientId>1694</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_9_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>15</age>
+						<patientId>1809</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_7_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>skin 2</tissue>
+					<tissueCell>
+						<cellType>epidermal cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>61</age>
+						<patientId>456</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+								<snomed tissueDescription="Anal" snomedCode="T-69000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_6_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>86</age>
+						<patientId>1813</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Vascular tissue" snomedCode="T-41000"/>
+								<snomed tissueDescription="Vulva" snomedCode="T-80100"/>
+								<snomed tissueDescription="Peripheral nerve tissue" snomedCode="T-X0500"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_4_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>46</age>
+						<patientId>1876</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Anal" snomedCode="T-69000"/>
+								<snomed tissueDescription="Peripheral nerve tissue" snomedCode="T-X0500"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_5_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>small intestine</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>51</age>
+						<patientId>202</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_5_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>59</age>
+						<patientId>969</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_4_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>smooth muscle</tissue>
+					<tissueCell>
+						<cellType>smooth muscle cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>56</age>
+						<patientId>1444</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Uterus" snomedCode="T-82000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_4_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>63</age>
+						<patientId>1647</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Duodenum" snomedCode="T-64300"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_5_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>45</age>
+						<patientId>1695</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Uterus" snomedCode="T-82000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_6_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>soft tissue 1</tissue>
+					<tissueCell>
+						<cellType>adipocytes</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>chondrocytes</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>fibroblasts</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>45</age>
+						<patientId>1447</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_2_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>44</age>
+						<patientId>1452</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_1_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>65</age>
+						<patientId>1470</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Cartilage tissue" snomedCode="T-1X700"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_3_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>soft tissue 2</tissue>
+					<tissueCell>
+						<cellType>adipocytes</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>fibroblasts</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>peripheral nerve</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>63</age>
+						<patientId>1647</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Duodenum" snomedCode="T-64300"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_1_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>52</age>
+						<patientId>1879</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Inflammation, NOS" snomedCode="M-40000"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+								<snomed tissueDescription="Peripheral nerve tissue" snomedCode="T-X0500"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_2_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>51</age>
+						<patientId>2143</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Sarcoma, NOS" snomedCode="M-88003"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+								<snomed tissueDescription="Soft tissue" snomedCode="T-1X000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_3_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>spleen</tissue>
+					<tissueCell>
+						<cellType>cells in red pulp</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>cells in white pulp</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>18</age>
+						<patientId>1375</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Spleen" snomedCode="T-07000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_8_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>21</age>
+						<patientId>1511</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Spleen" snomedCode="T-07000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_7_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>72</age>
+						<patientId>1714</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Spleen" snomedCode="T-07000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_9_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>stomach 1</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>57</age>
+						<patientId>266</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_6_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>47</age>
+						<patientId>1266</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_5_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>stomach 2</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>58</age>
+						<patientId>253</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Stomach, lower" snomedCode="T-63700"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_3_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>56</age>
+						<patientId>338</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Stomach, lower" snomedCode="T-63700"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_1_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>93</age>
+						<patientId>360</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Stomach, lower" snomedCode="T-63700"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_2_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>testis</tissue>
+					<tissueCell>
+						<cellType>cells in seminiferous ducts</cellType>
+						<level type="staining">medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>Leydig cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>38</age>
+						<patientId>305</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_6_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>29</age>
+						<patientId>556</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_5_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>57</age>
+						<patientId>1180</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_4_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>thyroid gland</tissue>
+					<tissueCell>
+						<cellType>glandular cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>34</age>
+						<patientId>1430</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_1_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>76</age>
+						<patientId>1436</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_2_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>55</age>
+						<patientId>1439</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_3_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>tonsil</tissue>
+					<tissueCell>
+						<cellType>germinal center cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>non-germinal center cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<tissueCell>
+						<cellType>squamous epithelial cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>6</age>
+						<patientId>321</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Tonsil" snomedCode="T-61100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_6_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>41</age>
+						<patientId>786</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Tonsil" snomedCode="T-61100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_4_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>58</age>
+						<patientId>829</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Tonsil" snomedCode="T-61100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_5_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>urinary bladder</tissue>
+					<tissueCell>
+						<cellType>urothelial cells</cellType>
+						<level type="staining">not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>85</age>
+						<patientId>1871</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_A_5_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>vagina</tissue>
+					<tissueCell>
+						<cellType>squamous epithelial cells</cellType>
+						<level type="staining">low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>34</age>
+						<patientId>1751</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Vagina" snomedCode="T-81000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_1_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>46</age>
+						<patientId>1762</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Vagina" snomedCode="T-81000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_2_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>68</age>
+						<patientId>1829</patientId>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Vagina" snomedCode="T-81000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2043_B_3_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+			</tissueExpression>
+			<tissueExpression source="HPA" technology="IHC" assayType="pathology">
+				<summary type="pathology"><![CDATA[Strong cytoplasmic positivity in a small fraction of malignant cells in most malignancies present were observed. Carcioids, urothelial, renal, stomach, panctreatic and liver cancers were generally negative.]]></summary>
+				<data>
+					<tissue>breast cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="2">high</level>
+						<level type="staining" count="2">medium</level>
+						<level type="staining" count="8">low</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>84</age>
+						<patientId>1432</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_4_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>93</age>
+						<patientId>1785</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_6_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_6_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>40</age>
+						<patientId>1838</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_4_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>50</age>
+						<patientId>1953</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_6_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>50</age>
+						<patientId>1977</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_6_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_6_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>55</age>
+						<patientId>2018</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Lobular carcinoma" snomedCode="M-85203"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_5_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Lobular carcinoma" snomedCode="M-85203"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_5_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>51</age>
+						<patientId>2073</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_6_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_6_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>51</age>
+						<patientId>2083</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Lobular carcinoma" snomedCode="M-85203"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_5_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Lobular carcinoma" snomedCode="M-85203"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_5_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>40</age>
+						<patientId>2091</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_4_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_4_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>37</age>
+						<patientId>2174</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_4_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_4_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>60</age>
+						<patientId>2199</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Lobular carcinoma" snomedCode="M-85203"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_5_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Lobular carcinoma" snomedCode="M-85203"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_5_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>27</age>
+						<patientId>2392</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_5_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Duct carcinoma" snomedCode="M-85003"/>
+								<snomed tissueDescription="Breast" snomedCode="T-04000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_5_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>carcinoid</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="4">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>76</age>
+						<patientId>227</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Stomach" snomedCode="T-63000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_1_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Stomach" snomedCode="T-63000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_1_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>63</age>
+						<patientId>604</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_1_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_1_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>60</age>
+						<patientId>997</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_1_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_1_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>55</age>
+						<patientId>1092</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Bronchus" snomedCode="T-26000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_1_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Bronchus" snomedCode="T-26000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_1_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>cervical cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="8">medium</level>
+						<level type="staining" count="1">low</level>
+						<level type="staining" count="2">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>32</age>
+						<patientId>334</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_4_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>40</age>
+						<patientId>978</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_6_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_6_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>33</age>
+						<patientId>1256</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_6_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_6_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>60</age>
+						<patientId>1291</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_4_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_4_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>36</age>
+						<patientId>1481</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_5_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_5_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>39</age>
+						<patientId>1716</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_5_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_5_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>36</age>
+						<patientId>1733</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_4_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_4_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>67</age>
+						<patientId>2054</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_5_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_5_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>36</age>
+						<patientId>2170</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_5_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_5_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>64</age>
+						<patientId>2237</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_6_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_6_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>38</age>
+						<patientId>2988</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_6_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Cervix" snomedCode="T-83000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_6_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>colorectal cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="6">high</level>
+						<level type="staining" count="2">medium</level>
+						<level type="staining" count="2">low</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>53</age>
+						<patientId>1390</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_1_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_1_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>70</age>
+						<patientId>1416</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Rectum" snomedCode="T-68000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_2_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>53</age>
+						<patientId>1424</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Rectum" snomedCode="T-68000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_2_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Rectum" snomedCode="T-68000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_2_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>46</age>
+						<patientId>1454</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_1_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_1_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>55</age>
+						<patientId>1506</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_2_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_2_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>71</age>
+						<patientId>1957</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Rectum" snomedCode="T-68000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_2_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Rectum" snomedCode="T-68000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_2_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>84</age>
+						<patientId>1958</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_3_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_3_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>82</age>
+						<patientId>2002</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_3_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_3_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>72</age>
+						<patientId>2096</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_1_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_1_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>86</age>
+						<patientId>2106</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_3_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>endometrial cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="1">high</level>
+						<level type="staining" count="6">medium</level>
+						<level type="staining" count="3">low</level>
+						<level type="staining" count="1">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>42</age>
+						<patientId>1102</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_9_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_9_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>66</age>
+						<patientId>1164</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_8_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_8_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>55</age>
+						<patientId>1739</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_9_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_9_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>53</age>
+						<patientId>1766</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_7_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_7_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>86</age>
+						<patientId>1881</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_8_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_8_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>74</age>
+						<patientId>1963</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Neoplasm, malignant, NOS" snomedCode="M-80003"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_9_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Neoplasm, malignant, NOS" snomedCode="M-80003"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_9_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>67</age>
+						<patientId>2113</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_9_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_9_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>70</age>
+						<patientId>2118</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Uterus" snomedCode="T-82000"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_7_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Uterus" snomedCode="T-82000"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_7_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>59</age>
+						<patientId>2122</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_7_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_7_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>66</age>
+						<patientId>2335</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_7_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_7_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>79</age>
+						<patientId>2339</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Necrosis, NOS" snomedCode="M-54000"/>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_8_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Necrosis, NOS" snomedCode="M-54000"/>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Endometrium" snomedCode="T-84000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_8_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>glioma</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="6">medium</level>
+						<level type="staining" count="1">low</level>
+						<level type="staining" count="5">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>68</age>
+						<patientId>3</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_6_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_6_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>36</age>
+						<patientId>34</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, Low grade" snomedCode="M-938031"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_4_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, Low grade" snomedCode="M-938031"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_4_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>36</age>
+						<patientId>38</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_4_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_4_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>72</age>
+						<patientId>45</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_5_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_5_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>77</age>
+						<patientId>46</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_6_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_6_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>60</age>
+						<patientId>105</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_5_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_5_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>15</age>
+						<patientId>158</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, Low grade" snomedCode="M-938031"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_6_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, Low grade" snomedCode="M-938031"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_6_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>46</age>
+						<patientId>176</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, Low grade" snomedCode="M-938031"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_6_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, Low grade" snomedCode="M-938031"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_6_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>48</age>
+						<patientId>183</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_5_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_5_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>69</age>
+						<patientId>191</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_5_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_5_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>66</age>
+						<patientId>206</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_4_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_4_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>37</age>
+						<patientId>221</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_4_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Glioma, malignant, High grade" snomedCode="M-938033"/>
+								<snomed tissueDescription="Brain" snomedCode="T-X2000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_4_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>head and neck cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="2">medium</level>
+						<level type="staining" count="1">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>74</age>
+						<patientId>807</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Squamous cell carcinoma, metastatic, NOS" snomedCode="M-80706"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+								<snomed tissueDescription="Salivary gland" snomedCode="T-55100"/>
+								<snomed tissueDescription="Head-Neck" snomedCode="T-Y0000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_2_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Squamous cell carcinoma, metastatic, NOS" snomedCode="M-80706"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+								<snomed tissueDescription="Salivary gland" snomedCode="T-55100"/>
+								<snomed tissueDescription="Head-Neck" snomedCode="T-Y0000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_2_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>70</age>
+						<patientId>1060</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Salivary gland" snomedCode="T-55100"/>
+								<snomed tissueDescription="Head-Neck" snomedCode="T-Y0000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_2_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Salivary gland" snomedCode="T-55100"/>
+								<snomed tissueDescription="Head-Neck" snomedCode="T-Y0000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_2_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>64</age>
+						<patientId>1130</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Head-Neck" snomedCode="T-Y0000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_2_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Head-Neck" snomedCode="T-Y0000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_2_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>liver cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="1">low</level>
+						<level type="staining" count="8">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>66</age>
+						<patientId>82</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_7_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_7_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>64</age>
+						<patientId>369</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_8_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_8_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>55</age>
+						<patientId>490</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cholangiocarcinoma" snomedCode="M-81603"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_8_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cholangiocarcinoma" snomedCode="M-81603"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_8_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>79</age>
+						<patientId>516</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cholangiocarcinoma" snomedCode="M-81603"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_9_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cholangiocarcinoma" snomedCode="M-81603"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_9_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>49</age>
+						<patientId>929</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_7_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_7_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>65</age>
+						<patientId>937</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cholangiocarcinoma" snomedCode="M-81603"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_9_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cholangiocarcinoma" snomedCode="M-81603"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_9_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>57</age>
+						<patientId>1175</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cholangiocarcinoma" snomedCode="M-81603"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_9_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cholangiocarcinoma" snomedCode="M-81603"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_9_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>24</age>
+						<patientId>1287</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_8_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_8_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>85</age>
+						<patientId>2662</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_7_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Hepatocellular, NOS" snomedCode="M-81703"/>
+								<snomed tissueDescription="Liver" snomedCode="T-56000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_7_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>lung cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="2">high</level>
+						<level type="staining" count="4">low</level>
+						<level type="staining" count="5">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>64</age>
+						<patientId>376</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_2_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_2_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>75</age>
+						<patientId>385</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_1_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_1_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>48</age>
+						<patientId>426</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_2_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_2_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>75</age>
+						<patientId>496</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Neoplasm, malignant, NOS" snomedCode="M-80003"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_3_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Neoplasm, malignant, NOS" snomedCode="M-80003"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_3_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>50</age>
+						<patientId>537</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_2_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_2_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>60</age>
+						<patientId>763</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_1_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoid, malignant, NOS" snomedCode="M-82403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_1_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>71</age>
+						<patientId>1199</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_3_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_3_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>44</age>
+						<patientId>1249</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_3_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_3_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>68</age>
+						<patientId>1303</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_3_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_3_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>64</age>
+						<patientId>1327</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_1_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_1_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>74</age>
+						<patientId>2663</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_1_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+								<snomed tissueDescription="Lung" snomedCode="T-28000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_1_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>lymphoma</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="2">high</level>
+						<level type="staining" count="6">medium</level>
+						<level type="staining" count="2">low</level>
+						<level type="staining" count="2">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>57</age>
+						<patientId>10</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_9_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_9_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>50</age>
+						<patientId>81</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_9_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_9_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>70</age>
+						<patientId>92</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, High grade" snomedCode="M-959133"/>
+								<snomed tissueDescription="Spleen" snomedCode="T-07000"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_7_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, High grade" snomedCode="M-959133"/>
+								<snomed tissueDescription="Spleen" snomedCode="T-07000"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_7_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>49</age>
+						<patientId>136</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_8_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_8_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>46</age>
+						<patientId>150</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Hodgkin's disease, NOS" snomedCode="M-96503"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_7_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Hodgkin's disease, NOS" snomedCode="M-96503"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_7_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>65</age>
+						<patientId>241</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_9_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_9_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>82</age>
+						<patientId>296</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, High grade" snomedCode="M-959133"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_9_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>69</age>
+						<patientId>314</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_8_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_8_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>74</age>
+						<patientId>425</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_8_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Lymph node" snomedCode="T-08000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_8_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>8</age>
+						<patientId>603</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, High grade" snomedCode="M-959133"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_7_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, High grade" snomedCode="M-959133"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+								<snomed tissueDescription="Colon" snomedCode="T-67000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_7_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>59</age>
+						<patientId>637</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_8_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, Low grade" snomedCode="M-959131"/>
+								<snomed tissueDescription="Small intestine" snomedCode="T-65000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_8_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>56</age>
+						<patientId>1090</patientId>
+						<level type="staining">High</level>
+						<level type="intensity">Strong</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, High grade" snomedCode="M-959133"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_7_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant lymphoma, non-Hodgkin's type, High grade" snomedCode="M-959133"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_7_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>melanoma</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="5">medium</level>
+						<level type="staining" count="4">low</level>
+						<level type="staining" count="2">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>85</age>
+						<patientId>165</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_4_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_4_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>76</age>
+						<patientId>179</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_5_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_5_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>67</age>
+						<patientId>281</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_6_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_6_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>55</age>
+						<patientId>397</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_4_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_4_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>64</age>
+						<patientId>656</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_5_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_5_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>56</age>
+						<patientId>744</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_4_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_4_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>52</age>
+						<patientId>1141</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_5_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>49</age>
+						<patientId>1145</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_6_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>77</age>
+						<patientId>1189</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_5_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_5_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>40</age>
+						<patientId>1226</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_4_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_4_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>36</age>
+						<patientId>1301</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_6_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Malignant melanoma, NOS" snomedCode="M-87203"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_6_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>ovarian cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="6">medium</level>
+						<level type="staining" count="3">low</level>
+						<level type="staining" count="2">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>37</age>
+						<patientId>857</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, mucinous, NOS" snomedCode="M-84703"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_2_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>36</age>
+						<patientId>1310</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, mucinous, NOS" snomedCode="M-84703"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_2_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>82</age>
+						<patientId>1401</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, serous, NOS" snomedCode="M-84413"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_3_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, serous, NOS" snomedCode="M-84413"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_3_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>50</age>
+						<patientId>1658</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, endometroid" snomedCode="M-83803"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_1_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, endometroid" snomedCode="M-83803"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_1_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>60</age>
+						<patientId>1745</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, endometroid" snomedCode="M-83803"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_1_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, endometroid" snomedCode="M-83803"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_1_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>73</age>
+						<patientId>1844</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, mucinous, NOS" snomedCode="M-84703"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_1_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, mucinous, NOS" snomedCode="M-84703"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_1_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>51</age>
+						<patientId>1911</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, endometroid" snomedCode="M-83803"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_2_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, endometroid" snomedCode="M-83803"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_2_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>54</age>
+						<patientId>2114</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, serous, NOS" snomedCode="M-84413"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_2_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, serous, NOS" snomedCode="M-84413"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_2_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>66</age>
+						<patientId>2149</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, serous, NOS" snomedCode="M-84413"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_3_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, serous, NOS" snomedCode="M-84413"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_3_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>42</age>
+						<patientId>2218</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, endometroid" snomedCode="M-83803"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_1_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, endometroid" snomedCode="M-83803"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_1_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>59</age>
+						<patientId>2347</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, serous, NOS" snomedCode="M-84413"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_3_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Cystadenocarcinoma, serous, NOS" snomedCode="M-84413"/>
+								<snomed tissueDescription="Ovary" snomedCode="T-87000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_B_3_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>pancreatic cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="11">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>52</age>
+						<patientId>170</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_5_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_5_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>66</age>
+						<patientId>317</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_4_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_4_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>70</age>
+						<patientId>582</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_6_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_6_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>64</age>
+						<patientId>646</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_5_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_5_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>70</age>
+						<patientId>823</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_5_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>70</age>
+						<patientId>834</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_4_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_4_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>77</age>
+						<patientId>893</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_4_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>59</age>
+						<patientId>969</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_6_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_6_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>57</age>
+						<patientId>977</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_4_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_4_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>77</age>
+						<patientId>1248</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_6_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_6_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>79</age>
+						<patientId>2650</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_6_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>prostate cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="2">medium</level>
+						<level type="staining" count="4">low</level>
+						<level type="staining" count="6">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>70</age>
+						<patientId>137</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_7_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_7_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>72</age>
+						<patientId>244</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_9_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_9_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>64</age>
+						<patientId>250</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_9_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_9_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>63</age>
+						<patientId>472</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_9_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_9_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>69</age>
+						<patientId>525</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Low grade" snomedCode="M-814031"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_8_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Low grade" snomedCode="M-814031"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_8_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>71</age>
+						<patientId>640</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_7_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_7_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>67</age>
+						<patientId>689</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_7_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_7_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>79</age>
+						<patientId>847</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_8_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_8_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>60</age>
+						<patientId>866</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_8_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_8_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>68</age>
+						<patientId>907</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_9_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, High grade" snomedCode="M-814033"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_9_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>53</age>
+						<patientId>994</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_7_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_7_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>64</age>
+						<patientId>1027</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_8_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, Medium grade" snomedCode="M-814032"/>
+								<snomed tissueDescription="Prostate" snomedCode="T-77100"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2138_A_8_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>renal cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="1">low</level>
+						<level type="staining" count="9">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>60</age>
+						<patientId>1722</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_9_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_9_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>46</age>
+						<patientId>1741</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_8_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_8_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>79</age>
+						<patientId>1749</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_9_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_9_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>56</age>
+						<patientId>1752</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_9_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_9_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>68</age>
+						<patientId>1786</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Inflammation, NOS" snomedCode="M-40000"/>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_8_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Inflammation, NOS" snomedCode="M-40000"/>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_8_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>77</age>
+						<patientId>1831</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_8_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_8_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>61</age>
+						<patientId>1859</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_8_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_8_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>56</age>
+						<patientId>1933</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_7_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_7_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>63</age>
+						<patientId>1969</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_7_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_7_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>71</age>
+						<patientId>2034</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_7_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Kidney" snomedCode="T-71000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_7_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>skin cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="6">medium</level>
+						<level type="staining" count="3">low</level>
+						<level type="staining" count="2">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>82</age>
+						<patientId>155</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_7_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_7_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>88</age>
+						<patientId>316</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_7_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_7_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>57</age>
+						<patientId>318</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_8_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_8_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>65</age>
+						<patientId>471</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_9_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_9_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>89</age>
+						<patientId>654</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_7_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_7_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>81</age>
+						<patientId>674</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_7_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>64</age>
+						<patientId>849</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+								<snomed tissueDescription="Anal" snomedCode="T-69000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_8_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Squamous cell carcinoma, NOS" snomedCode="M-80703"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+								<snomed tissueDescription="Anal" snomedCode="T-69000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_8_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>81</age>
+						<patientId>962</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_8_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_8_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>84</age>
+						<patientId>1246</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_9_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_9_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>81</age>
+						<patientId>1255</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_9_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>75</age>
+						<patientId>1279</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Strong</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_9_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Basal cell carcinoma" snomedCode="M-80903"/>
+								<snomed tissueDescription="Skin" snomedCode="T-01000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_B_9_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>stomach cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="1">low</level>
+						<level type="staining" count="9">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>80</age>
+						<patientId>198</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_2_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_2_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>86</age>
+						<patientId>549</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, lower" snomedCode="T-63700"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_3_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>50</age>
+						<patientId>664</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_2_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_2_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>71</age>
+						<patientId>703</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_1_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_1_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>77</age>
+						<patientId>893</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_1_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Pancreas" snomedCode="T-59000"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_1_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>76</age>
+						<patientId>1073</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_2_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_2_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>88</age>
+						<patientId>1158</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, lower" snomedCode="T-63700"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_3_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, lower" snomedCode="T-63700"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_3_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>78</age>
+						<patientId>1186</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach" snomedCode="T-63000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_1_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach" snomedCode="T-63000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_1_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>63</age>
+						<patientId>1207</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_3_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_3_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>47</age>
+						<patientId>1266</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_2_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Adenocarcinoma, NOS" snomedCode="M-81403"/>
+								<snomed tissueDescription="Stomach, upper" snomedCode="T-62350"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_B_2_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>testis cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="4">medium</level>
+						<level type="staining" count="4">low</level>
+						<level type="staining" count="3">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>52</age>
+						<patientId>138</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_1_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_1_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>39</age>
+						<patientId>411</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_1_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_1_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>28</age>
+						<patientId>1179</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Moderate</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Embryonal, NOS" snomedCode="M-90703"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_3_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Embryonal, NOS" snomedCode="M-90703"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_3_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>21</age>
+						<patientId>1340</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Embryonal, NOS" snomedCode="M-90703"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_3_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Embryonal, NOS" snomedCode="M-90703"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_3_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>34</age>
+						<patientId>1344</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Normal tissue, NOS" snomedCode="M-00100"/>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_2_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>33</age>
+						<patientId>1462</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Moderate</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_2_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_2_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>41</age>
+						<patientId>1700</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Moderate</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_2_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_2_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>36</age>
+						<patientId>1740</patientId>
+						<level type="staining">Medium</level>
+						<level type="intensity">Moderate</level>
+						<quantity>75%-25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Embryonal, NOS" snomedCode="M-90703"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_3_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Embryonal, NOS" snomedCode="M-90703"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_3_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>43</age>
+						<patientId>1777</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_2_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_2_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>59</age>
+						<patientId>1900</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_1_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Seminoma, NOS" snomedCode="M-90613"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_1_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>26</age>
+						<patientId>1995</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>&lt;25%</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Embryonal, NOS" snomedCode="M-90703"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_3_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, Embryonal, NOS" snomedCode="M-90703"/>
+								<snomed tissueDescription="Testis" snomedCode="T-78000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_3_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>thyroid cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="1">low</level>
+						<level type="staining" count="3">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Male</sex>
+						<age>76</age>
+						<patientId>306</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, NOS" snomedCode="M-80103"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_3_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Carcinoma, NOS" snomedCode="M-80103"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_3_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>87</age>
+						<patientId>348</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Papillary adenocarcinoma, NOS" snomedCode="M-82603"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_3_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>71</age>
+						<patientId>923</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Follicular adenoma carcinoma, NOS" snomedCode="M-83303"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_3_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Follicular adenoma carcinoma, NOS" snomedCode="M-83303"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_3_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>71</age>
+						<patientId>985</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Papillary adenocarcinoma, NOS" snomedCode="M-82603"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_3_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Papillary adenocarcinoma, NOS" snomedCode="M-82603"/>
+								<snomed tissueDescription="Thyroid gland" snomedCode="T-96000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2044_A_3_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+				<data>
+					<tissue>urothelial cancer</tissue>
+					<tissueCell>
+						<cellType>tumor cells</cellType>
+						<level type="staining" count="2">low</level>
+						<level type="staining" count="10">not detected</level>
+					</tissueCell>
+					<patient>
+						<sex>Female</sex>
+						<age>81</age>
+						<patientId>662</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_6_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_6_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>85</age>
+						<patientId>799</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, Low grade" snomedCode="M-812031"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_4_5.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, Low grade" snomedCode="M-812031"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_4_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>86</age>
+						<patientId>944</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, Low grade" snomedCode="M-812031"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_4_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, Low grade" snomedCode="M-812031"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_4_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>78</age>
+						<patientId>1441</patientId>
+						<level type="staining">Low</level>
+						<level type="intensity">Moderate</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_6_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_6_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>74</age>
+						<patientId>1651</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_5_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_5_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>50</age>
+						<patientId>1717</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_5_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_5_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>56</age>
+						<patientId>1760</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_5_6.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>55</age>
+						<patientId>1798</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_5_7.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_5_8.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>66</age>
+						<patientId>1824</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Negative</level>
+						<quantity>Negative</quantity>
+						<location>none</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_4_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>85</age>
+						<patientId>1871</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_6_1.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_6_2.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Male</sex>
+						<age>57</age>
+						<patientId>1906</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_4_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_4_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+					<patient>
+						<sex>Female</sex>
+						<age>80</age>
+						<patientId>2031</patientId>
+						<level type="staining">Not detected</level>
+						<level type="intensity">Weak</level>
+						<quantity>Rare</quantity>
+						<location>cytoplasmic/membranous,nuclear</location>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_6_3.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+						<sample>
+							<snomedParameters>
+								<snomed tissueDescription="Urothelial carcinoma, High grade" snomedCode="M-812033"/>
+								<snomed tissueDescription="Urinary bladder" snomedCode="T-74000"/>
+							</snomedParameters>
+							<assayImage>
+								<image imageType="sampleImage">
+									<imageUrl>http://v18.proteinatlas.org/images/115/2266_A_6_4.jpg</imageUrl>
+								</image>
+							</assayImage>
+						</sample>
+					</patient>
+				</data>
+			</tissueExpression>
+			<cellExpression source="HPA" technology="ICC/IF">
+				<subAssay type="human">
+					<verification type="validation">supported</verification>
+					<image imageType="selected" description="Immunofluorescent staining of human cell line U-2 OS shows localization to cytosol.">
+						<imageUrl>http://v18.proteinatlas.org/images/115/if_selected.jpg</imageUrl>
+					</image>
+					<data>
+						<cellLine>A-431</cellLine>
+						<location GOId="GO:0005829" singleCellVariationIntensity="true">cytosol</location>
+						<assayImage>
+							<image imageType="sampleImage">
+								<channel color="blue">nucleus</channel>
+								<channel color="red">microtubules</channel>
+								<channel color="green">antibody</channel>
+								<imageUrl>http://v18.proteinatlas.org/images/115/672_E2_1_blue_red_green.jpg</imageUrl>
+							</image>
+							<image imageType="sampleImage">
+								<channel color="blue">nucleus</channel>
+								<channel color="red">microtubules</channel>
+								<channel color="green">antibody</channel>
+								<imageUrl>http://v18.proteinatlas.org/images/115/672_E2_2_blue_red_green.jpg</imageUrl>
+							</image>
+						</assayImage>
+					</data>
+					<data>
+						<cellLine>U-2 OS</cellLine>
+						<location GOId="GO:0005829" singleCellVariationIntensity="true">cytosol</location>
+						<assayImage>
+							<image imageType="sampleImage">
+								<channel color="blue">nucleus</channel>
+								<channel color="red">microtubules</channel>
+								<channel color="green">antibody</channel>
+								<imageUrl>http://v18.proteinatlas.org/images/115/663_E2_1_blue_red_green.jpg</imageUrl>
+							</image>
+							<image imageType="sampleImage">
+								<channel color="blue">nucleus</channel>
+								<channel color="red">microtubules</channel>
+								<channel color="green">antibody</channel>
+								<imageUrl>http://v18.proteinatlas.org/images/115/663_E2_5_blue_red_green.jpg</imageUrl>
+							</image>
+						</assayImage>
+					</data>
+					<data>
+						<cellLine>U-251 MG</cellLine>
+						<location GOId="GO:0005829" singleCellVariationIntensity="true">cytosol</location>
+						<assayImage>
+							<image imageType="sampleImage">
+								<channel color="blue">nucleus</channel>
+								<channel color="red">microtubules</channel>
+								<channel color="green">antibody</channel>
+								<imageUrl>http://v18.proteinatlas.org/images/115/646_E2_1_blue_red_green.jpg</imageUrl>
+							</image>
+							<image imageType="sampleImage">
+								<channel color="blue">nucleus</channel>
+								<channel color="red">microtubules</channel>
+								<channel color="green">antibody</channel>
+								<imageUrl>http://v18.proteinatlas.org/images/115/646_E2_2_blue_red_green.jpg</imageUrl>
+							</image>
+						</assayImage>
+					</data>
+				</subAssay>
+			</cellExpression>
+			<westernBlot source="HPA" technology="WB">
+				<verification type="validation" description="Single band corresponding to the predicted size in kDa (+/-20%).">supported</verification>
+				<antibodyDilution dilution="1:500"/>
+				<image imageType="assay">
+					<imageUrl>http://v18.proteinatlas.org/images_western_blot/115_medium.jpg</imageUrl>
+				</image>
+				<blotLanes>
+					<lane laneId="1" laneContent="Marker">
+						<weight value="250" unit="kDa"/>
+						<weight value="130" unit="kDa"/>
+						<weight value="95" unit="kDa"/>
+						<weight value="72" unit="kDa"/>
+						<weight value="55" unit="kDa"/>
+						<weight value="36" unit="kDa"/>
+						<weight value="28" unit="kDa"/>
+						<weight value="17" unit="kDa"/>
+						<weight value="11" unit="kDa"/>
+					</lane>
+					<lane laneId="2" laneContent="RT4"/>
+					<lane laneId="3" laneContent="U-251 MG"/>
+					<lane laneId="4" laneContent="Human Plasma"/>
+					<lane laneId="5" laneContent="Liver"/>
+					<lane laneId="6" laneContent="Tonsil"/>
+				</blotLanes>
+			</westernBlot>
+		</antibody>
+	</entry>
+	<copyright>Copyrighted by the Human Protein Atlas, http://www.proteinatlas.org/about/licence</copyright>
+</proteinAtlas>

--- a/vignettes/a_HPAanalyze_quick_start.Rmd
+++ b/vignettes/a_HPAanalyze_quick_start.Rmd
@@ -50,7 +50,7 @@ The Human Protein Atlas project provides data via two main mechanisms: *Full dat
 
 Currently, this is available for the normal tissue, pathology (cancers) and subcellular location datasets. The fastest and easiest way is to use the defaults of `hpaVis`.
 
-```{r hpaVis_eg}
+```{r hpaVis_eg, fig.width=10, fig.height=8}
 hpaVis(targetGene = c("GCH1", "PTS", "SPR", "DHFR"),
        targetTissue = c("Cerebellum", "Cerebral cortex", "Hippocampus"),
        targetCancer = c("glioma"))

--- a/vignettes/a_HPAanalyze_quick_start.Rmd
+++ b/vignettes/a_HPAanalyze_quick_start.Rmd
@@ -26,7 +26,6 @@ knitr::opts_chunk$set(
 ```
 
 ```{r library, message=FALSE, warning=FALSE, error=FALSE}
-# library(BiocStyle)
 library(HPAanalyze)
 library(dplyr)
 ```

--- a/vignettes/b_HPAanalyze_indepth.Rmd
+++ b/vignettes/b_HPAanalyze_indepth.Rmd
@@ -27,7 +27,6 @@ knitr::opts_chunk$set(
 ```
 
 ```{r library}
-library(BiocStyle)
 library(HPAanalyze)
 library(tibble)
 library(dplyr)

--- a/vignettes/b_HPAanalyze_indepth.Rmd
+++ b/vignettes/b_HPAanalyze_indepth.Rmd
@@ -214,7 +214,7 @@ downloadedData <- hpaDownload('histology', 'example')
 
 `hpaVis` will plot all available plots by default. See the quick-start vignette for details.
 
-```{r hpaVis_eg}
+```{r hpaVis_eg, fig.width=10, fig.height=8}
 hpaVis(downloadedData,
        targetGene = c("GCH1", "PTS", "SPR", "DHFR"),
        targetTissue = c("Cerebellum", "Cerebral cortex", "Hippocampus"),

--- a/vignettes/c_HPAanalyze_case_query.Rmd
+++ b/vignettes/c_HPAanalyze_case_query.Rmd
@@ -27,7 +27,6 @@ knitr::opts_chunk$set(
 ```
 
 ```{r library, message=FALSE, warning=FALSE, error=FALSE}
-library(BiocStyle)
 library(HPAanalyze)
 library(dplyr)
 library(tibble)

--- a/vignettes/d_HPAanalyze_case_offline_xml.Rmd
+++ b/vignettes/d_HPAanalyze_case_offline_xml.Rmd
@@ -26,7 +26,6 @@ knitr::opts_chunk$set(
 ```
 
 ```{r library, message=FALSE, warning=FALSE, error=FALSE}
-library(BiocStyle)
 library(HPAanalyze)
 library(dplyr)
 library(xml2)

--- a/vignettes/e_HPAanalyze_case_json.Rmd
+++ b/vignettes/e_HPAanalyze_case_json.Rmd
@@ -26,7 +26,6 @@ knitr::opts_chunk$set(
 ```
 
 ```{r library, message=FALSE, warning=FALSE, error=FALSE}
-library(BiocStyle)
 library(HPAanalyze)
 library(dplyr)
 library(jsonlite)

--- a/vignettes/f_HPAanalyze_case_images.Rmd
+++ b/vignettes/f_HPAanalyze_case_images.Rmd
@@ -26,7 +26,6 @@ knitr::opts_chunk$set(
 ```
 
 ```{r library, message=FALSE, warning=FALSE, error=FALSE}
-library(BiocStyle)
 library(HPAanalyze)
 library(dplyr)
 ```

--- a/vignettes/z_HPAanalyze_paper_figures.Rmd
+++ b/vignettes/z_HPAanalyze_paper_figures.Rmd
@@ -26,7 +26,6 @@ knitr::opts_chunk$set(
 ```
 
 ```{r library, message=FALSE, warning=FALSE, error=FALSE}
-library(BiocStyle)
 library(HPAanalyze)
 library(dplyr)
 library(ggplot2)


### PR DESCRIPTION
## Summary

Adds a `testthat` unit test suite to HPAanalyze for the first time (previously the package had none, and CI didn't run tests), fixes a real plot-rendering bug uncovered in the process, and cleans up an unused dependency and some dead code — plus a couple of CI-infrastructure fixes discovered while getting everything green.

## Test suite (new)

- Added `tests/testthat/` with 5 test files and **69 tests**, covering:
  - `test-utils.R` — gene/ensembl conversion, URL building, `is_null_data()`, tibble reshaping.
  - `test-download.R` — `hpaDownload()` listing/example-dataset behavior, internal shortcut-expansion helpers.
  - `test-subset-export.R` — `hpaSubset()`, `hpaListParam()`, and `hpaExport()` (xlsx/csv/tsv).
  - `test-vis.R` — `hpaVisTissue()`/`hpaVisPatho()`/`hpaVisSubcell()`/`hpaVis()` return types and key plotting defaults (including that tiles stay square by default).
  - `test-xml.R` — `hpaXml*()` extractors, using a real HPA XML file (already bundled for the offline-XML vignette) as an offline fixture, so nothing here needs network access.
- Added `DESCRIPTION: Suggests: testthat (>= 3.0.0)` and `Config/testthat/edition: 3`.
- `tests/testthat.R` skips the whole suite specifically when run on Bioconductor's build machines (`IS_BIOC_BUILD_MACHINE`, the same variable `testthat::skip_on_bioc()` checks) — a deliberate choice, not an oversight, since Bioconductor's build infrastructure is separate from this repo's GitHub Actions workflows and the maintainer opted to keep it off there. The suite still runs in full on every GitHub Actions workflow and locally.

## Bug fix: disproportionate `hpaVis()` plots

Root-caused and fixed a real rendering bug: `hpaVis()` combines multiple plots via `gridExtra::grid.arrange()`, and `hpaVisTissue()`/`hpaVisSubcell()`'s `coord_equal()` (which keeps heatmap tiles square — long-standing, intentional behavior, kept as-is) locks each panel's aspect ratio to its data range. When a grid cell's shape doesn't match that locked aspect at the vignette's default 8×6in figure size, ggplot2 shrinks the panel to fit while axis text (sized in points, independent of figure size) stays full-size — producing exactly the "huge overlapping text, tiny graphics" look reported.

Fix applied at the **vignette level**, not in the plotting functions: bumped `fig.width`/`fig.height` to 10×8 on just the two `hpaVis_eg` chunks (in `a_HPAanalyze_quick_start.Rmd` and `b_HPAanalyze_indepth.Rmd`) that call the combined, multi-panel `hpaVis()` — every other chunk, which renders a single `hpaVis*` plot, already looked correct at the default size and is untouched. Verified by fully rendering the quick-start vignette end-to-end and inspecting the output image.

## Dependency cleanup

- Removed `BiocStyle` from `DESCRIPTION` `Suggests` and from every vignette's `library()` calls. It was only ever loaded for a side effect on figure layout (now fixed properly above) — no vignette uses its markdown helpers (`Biocpkg()`, `CRANpkg()`, etc.). This also removes a Bioconductor-only dependency that made `b_HPAanalyze_indepth.Rmd` fail to build in any non-Bioconductor-connected environment.
- Removed long-dead commented-out code (superseded `tidyr`-based implementations, an unused `list_to_df()` helper) from `R/utils.R`, `R/vis.R`, `R/xml.R`.
- Swapped `1:length(data)` for `seq_along(data)` in `hpaExport()`'s csv/tsv loops (`R/download.R`) so it doesn't misbehave on a zero-length list.

## CI fixes

- **`test-vis.R` on ggplot2 4.0.3**: GitHub Actions installs whatever ggplot2 is latest on CRAN (no version pin), which is now a major rewrite (4.0.3). The square-tile test asserted the internal `"CoordFixed"` S3 class on `plot$coordinates`, which changed representation under 4.0.3. Reworded the assertion to check `coordinates$ratio == 1` instead — the actual public, documented argument `coord_equal()`/`coord_fixed()` are built from, rather than an internal class name. Confirmed via CI that this both passes on 4.0.3 and correctly reflects that `coord_equal()` is still applying a fixed aspect (no real regression).
- **macOS `Run BiocCheck` failure** (pre-existing on this repo, unrelated to any change here — confirmed present on this branch's very first commit, while `devel`'s last actually-tested run in Dec 2025 was green): `.github/workflows/check-bioc.yml` hardcoded `XML_CONFIG=/usr/local/opt/libxml2/bin/xml2-config` for installing the `XML` package from source. `macos-latest` runners are now Apple Silicon, where Homebrew installs to `/opt/homebrew`, not `/usr/local`, so that path never existed and `XML`'s build silently failed. Fixed by resolving the prefix dynamically via `` `brew --prefix libxml2` ``, which works on both Intel and Apple Silicon runners.

## Review feedback addressed

GitHub Copilot's automated review left 3 comments (see inline replies for details):
- ✅ Fixed: hardcoded `version = "v25"` in a download-list test now derives the version from `hpa_download_list$version_number` instead, so it stays aligned with the bundled data if/when it's refreshed.
- ↩️ Replied, no change: a claim that `expect_message()` requires *every* captured message to match — verified empirically against the exact testthat version CI uses; it matches on any captured message, so the flagged test isn't actually flaky.
- ↩️ Replied, no change: a suggestion to always run the full suite on Bioconductor rather than skip it — this was a deliberate maintainer decision (see Test suite section above), not an oversight.

## CI status

All 14 checks passing on the current head commit: `R-CMD-check` (ubuntu × devel/release/oldrel-1, macOS, Windows) and `R-CMD-check-bioc` (ubuntu/macOS/Windows × `Run CMD check` + `Run BiocCheck`), plus `pkgdown` and `docker-build-and-push`.